### PR TITLE
Fix docker.md link address

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -4,7 +4,7 @@ All interactions with the Exercism website are handled automatically. Test runne
 
 ## Execution
 
-- A test runner should provide an executable script. You can find more information in the [docker.md](https://github.com/exercism/automated-mentoring-support/blob/master/docs/docker.md) file.
+- A test runner should provide an executable script. You can find more information in the [docker.md](./docker.md) file.
 - The script will receive three parameters:
   - The slug of the exercise (e.g. `two-fer`).
   - A path to an input directory containing the submitted solution file(s) and the necessary test file(s) (with a trailing slash).


### PR DESCRIPTION
Right now, the docker.md link is taking me to the automated-analysis repository.