### PR TITLE
[Docs] Remove stack trace reference

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -40,7 +40,7 @@ The following overall statuses are valid:
 
 #### Message
 
-Where the status is `error` (the tests fail to execute cleanly), the top level `message` key should be provided. It should provide the occurring error to the user. As it is the only piece of information a user will receive on how to debug their issue, it must be as clear as possible.. For example, in Ruby, in the case of a syntax error, we provide the error and stack trace. In compiled languages, the compilation error should be provided.
+Where the status is `error` (the tests fail to execute cleanly), the top level `message` key should be provided. It should provide the occurring error to the user. As it is the only piece of information a user will receive on how to debug their issue, it must be as clear as possible.. For example, in Ruby, in the case of a syntax error, we provide the error. In compiled languages, the compilation error should be provided.
 
 When the status is not `error`, either set the value to `null` or omit the key entirely.
 


### PR DESCRIPTION
I think it might make sense to remove it here. If track's want to add it, they can, but I feel like we should not necessarily encourage including stack traces.