### PR TITLE
Update interface.md

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -98,6 +98,31 @@ The purpose of Exercism is to teach programming language fluency. Testing is a s
 
 All this to say, the separate keys exist to facilitate a very plain, human approach to the test suite for each language. It facilitates the website UI/UX, which may or may not show the test suite to the student.
 
+### UI/UX concerns
+
+#### On test failure
+
+When a student's solution fails a test, it should display something like:
+
+```text
+We ran:
+  <cmd>
+
+It resulted in:
+  <message>
+```
+
+#### On test success
+
+When the solution passes a test, it should display something like:
+
+```text
+We ran:
+  <cmd>
+Succeeded with:
+  <expected>
+```
+
 ### How to add metadata for your language's test suite
 
 All roads lead to rome and there is no prescribed pattern to arrive at this, there are several approaches taken so far:

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -54,7 +54,7 @@ When the status is not `error`, either set the value to `null` or omit the key e
 
 ### Per-test
 
-#### Statuses
+#### Status
 
 > key: `status`
 
@@ -63,7 +63,7 @@ The following per-test statuses are valid:
 - `fail`: The test failed
 - `error`: The test errored
 
-#### Messages
+#### Message
 
 > key: `message`
 
@@ -125,7 +125,7 @@ Succeeded with:
 
 ### How to add metadata for your language's test suite
 
-All roads lead to rome and there is no prescribed pattern to arrive at this, there are several approaches taken so far:
+All roads lead to Rome and there is no prescribed pattern to arrive at this. There are several approaches taken so far:
 
 - Auxillary JSON files compiled manually, merged with test results during the test run-time.
 - Automated static analysis of the test suite, merged with test results during the test run-time.

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -94,9 +94,9 @@ This is the value that is expected from the command (see `"cmd"` key) being test
 
 ## Why have separate command and expected keys
 
-The purpose of exercism is to teach programming language fluency.  Testing is a specific concept all to itself in each language: how it is performed, what strategies to use, best-practices, etc. Requiring students to learn the test framework to understand very early exercises is counter-intuitive to the approach of language _fluency_.
+The purpose of Exercism is to teach programming language fluency. Testing is a specific concept all to itself in each language: how it is performed, what strategies to use, best-practices, etc. Requiring students to learn the test framework to understand very early exercises is counter-intuitive to the approach of language _fluency_.
 
-All this to say, the separate keys exist to facilitate a very plain, human approach to the test suite for each language.  It facilitates the website UI/UX, which may or may not show the test suite to the student.
+All this to say, the separate keys exist to facilitate a very plain, human approach to the test suite for each language. It facilitates the website UI/UX, which may or may not show the test suite to the student.
 
 ### How to add metadata for your language's test suite
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -25,7 +25,9 @@ The `results.json` file should be structured as followed:
       "name": "Test that the thing works",
       "status": "fail",
       "message": "Expected 42 but got 123123",
-      "output": "Debugging information output by the user"
+      "output": "Debugging information output by the user",
+      "cmd": "answerToTheUltimateQuestion()",
+      "expected": "42"
     }
   ]
 }
@@ -33,12 +35,18 @@ The `results.json` file should be structured as followed:
 
 ### Top level
 
+#### Status
+
+> key: `status`
+
 The following overall statuses are valid:
 - `pass`: All tests passed
 - `fail`: At least one test failed
 - `error`: To be used when the tests did not run correctly (e.g. a compile error, a syntax error)
 
 #### Message
+
+> key: `message`
 
 Where the status is `error` (the tests fail to execute cleanly), the top level `message` key should be provided. It should provide the occurring error to the user. As it is the only piece of information a user will receive on how to debug their issue, it must be as clear as possible.. For example, in Ruby, in the case of a syntax error, we provide the error and stack trace. In compiled languages, the compilation error should be provided.
 
@@ -48,6 +56,8 @@ When the status is not `error`, either set the value to `null` or omit the key e
 
 #### Statuses
 
+> key: `status`
+
 The following per-test statuses are valid:
 - `pass`: The test passed
 - `fail`: The test failed
@@ -55,9 +65,13 @@ The following per-test statuses are valid:
 
 #### Messages
 
-The per-test `message` key can be used to display human-readable error messages. Presume that whatever is written here will be displayed to the student. If there is no error message, either set the value to `null` or omit the key entirely.
+> key: `message`
+
+The per-test `message` key can be used to display human-readable error messages. Presume that whatever is written here will be displayed to the student. If there is no error message, either set the value to `null` or omit the key entirely. It is also permissible to output test suite output here.
 
 #### Output
+
+> key: `output`
 
 The per-test `output` key should be used to store and output anything that a user deliberately outputs for a test.
 
@@ -65,6 +79,32 @@ The per-test `output` key should be used to store and output anything that a use
 - Only content outputted by a user manually should show - not automatic output by the test-runner.
 - You may either capture content that is output through normal means (e.g. `puts` in Ruby, `print` in Python or `Debug.WriteLine` in C#), or you may provide a method that the user may use (e.g. the Ruby Test Runner provides a user with a globally available `debug` method that they can use, which has the same characteristics as the standard `puts` method).
 - The output **must** be limited to 500 chars. Either truncating with a message of "Output was truncated. Please limit to 500 chars" or returning an error in this situation are acceptible.
+
+#### Command
+
+> key: `cmd`
+
+This is the command that is being tested, apart from any test-suite-specific function and/or special syntax. The purpose of this is to clearly state what code is evaluated and subsequently failing the test.
+
+#### Expected
+
+> key: `expected`
+
+This is the value that is expected from the command (see `"cmd"` key) being tested, apart from any test-specific functions and/or special syntax. The purpose of this is to clearly state what value is expected when the command is evaluated.
+
+## Why have separate command and expected keys
+
+The purpose of exercism is to teach programming language fluency.  Testing is a specific concept all to itself in each language: how it is performed, what strategies to use, best-practices, etc. Requiring students to learn the test framework to understand very early exercises is counter-intuitive to the approach of language _fluency_.
+
+All this to say, the separate keys exist to facilitate a very plain, human approach to the test suite for each language.  It facilitates the website UI/UX, which may or may not show the test suite to the student.
+
+### How to add metadata for your language's test suite
+
+All roads lead to rome and there is no prescribed pattern to arrive at this, there are several approaches taken so far:
+
+- Auxillary JSON files compiled manually, merged with test results during the test run-time.
+- Automated static analysis of the test suite, merged with test results during the test run-time.
+  - This may be accomplished by AST analysis or text-parsing
 
 ## Debugging
 


### PR DESCRIPTION
## Purpose

To update `interface.md` to reflect the current _defacto_ interface with respect to [@thelostlambda's post](https://github.com/exercism/v3/issues/2535) and discussions on slack/weekly call.

## Limitations

Please comment and/or review if I have over-looked or misstated something about the current _defacto_ interface.

I don't think this is the place for a debate about whether this is the right implementation or not, because as it is this seems to be the spec that implementations are moving toward and have already implemented with respect to the exercism-research initiative.

## Proposals

I would also propose that a 7th optional key would be added to the `per-test` object called `metadata-error` to provide a graceful fallback in the event that some aspect of the metadata generation fails.

Reasons I could envision this failing is:
- evolution/changes to the test suite not reflected in the manual compilation of metadata in `tests.json`
- unexpected assert/refute structure not accounted for by the automated generation of the metadata